### PR TITLE
Use regex to ignore special characters when searching

### DIFF
--- a/app/src/main/java/com/sduduzog/slimlauncher/models/AddAppViewModel.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/models/AddAppViewModel.kt
@@ -10,6 +10,7 @@ import javax.inject.Inject
 class AddAppViewModel @Inject constructor (baseDao: BaseDao) : ViewModel() {
     private val repository = Repository(baseDao)
     private var filterQuery = ""
+    private val regex = Regex("[^A-Za-z0-9]")
     private val _installedApps = mutableListOf<App>()
     private val _homeApps = mutableListOf<App>()
     private val homeAppsObserver = Observer<List<HomeApp>> {
@@ -24,13 +25,13 @@ class AddAppViewModel @Inject constructor (baseDao: BaseDao) : ViewModel() {
     }
 
     fun filterApps(query: String = "") {
-        this.filterQuery = query
+        this.filterQuery = regex.replace(query, "")
         this.updateDisplayedApps()
     }
 
     private fun updateDisplayedApps() {
         val filteredApps = _installedApps.filterNot { _homeApps.contains(it) }
-        this.apps.postValue(filteredApps.filter { it.appName.contains(filterQuery) })
+        this.apps.postValue(filteredApps.filter { regex.replace(it.appName, "").contains(filterQuery, ignoreCase = true) })
     }
 
     fun setInstalledApps(apps: List<App>) {

--- a/app/src/main/java/com/sduduzog/slimlauncher/models/AddAppViewModel.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/models/AddAppViewModel.kt
@@ -10,7 +10,7 @@ import javax.inject.Inject
 class AddAppViewModel @Inject constructor (baseDao: BaseDao) : ViewModel() {
     private val repository = Repository(baseDao)
     private var filterQuery = ""
-    private val regex = Regex("[^A-Za-z0-9]")
+    private val regex = Regex("[!@#\$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]")
     private val _installedApps = mutableListOf<App>()
     private val _homeApps = mutableListOf<App>()
     private val homeAppsObserver = Observer<List<HomeApp>> {

--- a/app/src/main/java/com/sduduzog/slimlauncher/models/AddAppViewModel.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/models/AddAppViewModel.kt
@@ -10,7 +10,7 @@ import javax.inject.Inject
 class AddAppViewModel @Inject constructor (baseDao: BaseDao) : ViewModel() {
     private val repository = Repository(baseDao)
     private var filterQuery = ""
-    private val regex = Regex("[!@#\$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]")
+    private val regex = Regex("[!@#\$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/? ]")
     private val _installedApps = mutableListOf<App>()
     private val _homeApps = mutableListOf<App>()
     private val homeAppsObserver = Observer<List<HomeApp>> {


### PR DESCRIPTION
Should solve #70.

To ignore special characters I used a list of allowed characters at first, but this didn't seem to work with non-latin input (tested with Greek). So instead it now uses a list of characters to ignore.

![search_example](https://user-images.githubusercontent.com/7763136/86972601-7f568d80-c173-11ea-9c85-955b5c9e0a21.png)
