### PR TITLE
Follow system for time format

### DIFF
--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/dialogs/ChooseTimeFormatDialog.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/dialogs/ChooseTimeFormatDialog.kt
@@ -17,14 +17,12 @@ class ChooseTimeFormatDialog : DialogFragment(){
         val builder = AlertDialog.Builder(context!!)
         settings = context!!.getSharedPreferences(getString(R.string.prefs_settings), MODE_PRIVATE)
 
-        val is24Hour = settings.getBoolean(getString(R.string.prefs_settings_key_time_format), true)
-        val index = if (is24Hour) 1 else 0
+        val active = settings.getInt(getString(R.string.prefs_settings_key_time_format), 0)
         builder.setTitle(R.string.choose_time_format_dialog_title)
-        builder.setSingleChoiceItems(R.array.time_format_array, index) {dialogInterface, i ->
+        builder.setSingleChoiceItems(R.array.time_format_array, active) {dialogInterface, i ->
             dialogInterface.dismiss()
             settings.edit {
-                val b = i != 0
-                putBoolean(getString(R.string.prefs_settings_key_time_format), b)
+                putInt(getString(R.string.prefs_settings_key_time_format), i)
             }
 
         }

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
@@ -18,6 +18,7 @@ import com.sduduzog.slimlauncher.utils.BaseFragment
 import com.sduduzog.slimlauncher.utils.OnLaunchAppListener
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.android.synthetic.main.home_fragment.*
+import java.text.DateFormat
 import java.text.SimpleDateFormat
 import java.util.*
 import javax.inject.Inject
@@ -137,16 +138,18 @@ class HomeFragment : BaseFragment(), OnLaunchAppListener {
     }
 
     fun updateClock() {
-        val twenty4Hour = context?.getSharedPreferences(getString(R.string.prefs_settings), Context.MODE_PRIVATE)
-                ?.getBoolean(getString(R.string.prefs_settings_key_time_format), true)
+        val active = context?.getSharedPreferences(getString(R.string.prefs_settings), Context.MODE_PRIVATE)
+                ?.getInt(getString(R.string.prefs_settings_key_time_format), 0)
         val date = Date()
-        if (twenty4Hour as Boolean) {
-            val fWatchTime = SimpleDateFormat("h:mm aa", Locale.ROOT)
-            home_fragment_time.text = fWatchTime.format(date)
-        } else {
-            val fWatchTime = SimpleDateFormat("H:mm", Locale.ROOT)
-            home_fragment_time.text = fWatchTime.format(date)
+
+        val fWatchTime = when(active) {
+            1 -> SimpleDateFormat("H:mm", Locale.ROOT)
+            2 -> SimpleDateFormat("h:mm aa", Locale.ROOT)
+            else -> DateFormat.getTimeInstance(DateFormat.SHORT)
         }
+        home_fragment_time.text = fWatchTime.format(date)
+
+
         val fWatchDate = SimpleDateFormat("EEE, MMM dd", Locale.ROOT)
         home_fragment_date.text = fWatchDate.format(date)
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,13 +14,14 @@
     </string-array>
 
     <string-array name="time_format_array">
+        <item>Follow system settings</item>
         <item>24 Hour</item>
         <item>12 Hour</item>
     </string-array>
 
     <string name="prefs_settings" translatable="false">settings</string>
     <string name="prefs_settings_key_theme" translatable="false">key_theme</string>
-    <string name="prefs_settings_key_time_format" translatable="false">clock_type</string>
+    <string name="prefs_settings_key_time_format" translatable="false">time_format</string>
     <string name="prefs_settings_key_toggle_status_bar" translatable="false">hide_status_bar</string>
     <string name="choose_time_format_dialog_title">Choose Time Format</string>
     <string name="main_fragment_options">Options</string>


### PR DESCRIPTION
Follow system settings for time format. Added it as an option, but as a user would also be fine with it being the default without any option to change it. 

Had to change the location (`clock_type` &rarr; `time_format`) to store the result, since the type has changed from bool to int, otherwise existing users would have a crashing launcher since `getInt` would return a boolean. 

Unfortunately all the default formats for the date include the year, so left that as it is for now.  