### PR TITLE
Update sorting_index on removal of homeapp

### DIFF
--- a/app/src/main/java/com/sduduzog/slimlauncher/data/BaseDao.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/data/BaseDao.kt
@@ -16,6 +16,18 @@ interface BaseDao {
     @Update(onConflict = OnConflictStrategy.REPLACE)
     fun update(vararg apps: HomeApp)
 
+    @Transaction
+    fun remove(app: HomeApp){
+        removeFromTable(app)
+        updateIndices(app.sortingIndex)
+    }
+
     @Delete
-    fun remove(vararg app: HomeApp)
+    fun removeFromTable(app: HomeApp)
+
+    @Query("UPDATE home_apps SET sorting_index = sorting_index - 1 WHERE sorting_index > :sortingIndex")
+    fun updateIndices(sortingIndex : Int)
+
+    @Query("DELETE FROM home_apps")
+    fun clearTable()
 }

--- a/app/src/main/java/com/sduduzog/slimlauncher/models/CustomiseAppsViewModel.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/models/CustomiseAppsViewModel.kt
@@ -25,7 +25,11 @@ class CustomiseAppsViewModel @Inject constructor(baseDao: BaseDao) : ViewModel()
         homeApp.appNickname = null
         update(homeApp)
     }
-    fun remove(vararg app: HomeApp) {
-        repository.remove(*app)
+    fun remove(app: HomeApp) {
+        repository.remove(app)
+    }
+
+    fun clearTable(){
+        repository.clearTable()
     }
 }

--- a/app/src/main/java/com/sduduzog/slimlauncher/models/MainViewModel.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/models/MainViewModel.kt
@@ -3,7 +3,6 @@ package com.sduduzog.slimlauncher.models
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import com.sduduzog.slimlauncher.data.BaseDao
-import com.sduduzog.slimlauncher.data.model.App
 import javax.inject.Inject
 
 class MainViewModel @Inject constructor(baseDao: BaseDao) : ViewModel() {
@@ -18,17 +17,4 @@ class MainViewModel @Inject constructor(baseDao: BaseDao) : ViewModel() {
 
     val apps: LiveData<List<HomeApp>>
         get() = _apps
-
-    fun add(app: App) {
-        val index = _apps.value!!.size
-        _baseRepository.add(HomeApp.from(app, index))
-    }
-
-    fun update(vararg args: HomeApp) {
-        _baseRepository.update(*args)
-    }
-
-    fun remove(vararg app: HomeApp) {
-        _baseRepository.remove(*app)
-    }
 }

--- a/app/src/main/java/com/sduduzog/slimlauncher/models/Repository.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/models/Repository.kt
@@ -17,12 +17,16 @@ class Repository(private val baseDao: BaseDao) {
         AddAppAsyncTask(baseDao).execute(app)
     }
 
-    fun update(vararg list: HomeApp) {
+    fun update(vararg list : HomeApp) {
         UpdateAppAsyncTask(baseDao).execute(*list)
     }
 
-    fun remove(vararg app: HomeApp) {
-        RemoveAppAsyncTask(baseDao).execute(*app)
+    fun remove(app: HomeApp) {
+        RemoveAppAsyncTask(baseDao).execute(app)
+    }
+
+    fun clearTable(){
+        ClearTableAsyncTask(baseDao).execute()
     }
 
     private class AddAppAsyncTask(private val mAsyncTaskDao: BaseDao) : AsyncTask<HomeApp, Void, Void>() {
@@ -44,7 +48,15 @@ class Repository(private val baseDao: BaseDao) {
     private class RemoveAppAsyncTask(private val mAsyncTaskDao: BaseDao) : AsyncTask<HomeApp, Void, Void>() {
 
         override fun doInBackground(vararg params: HomeApp): Void? {
-            mAsyncTaskDao.remove(*params)
+            mAsyncTaskDao.remove(params[0])
+            return null
+        }
+    }
+
+    private class ClearTableAsyncTask(private val mAsyncTaskDao: BaseDao) : AsyncTask<Void, Void, Void>() {
+
+        override fun doInBackground(vararg params: Void): Void? {
+            mAsyncTaskDao.clearTable()
             return null
         }
     }

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/dialogs/RemoveAllAppsDialog.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/dialogs/RemoveAllAppsDialog.kt
@@ -5,8 +5,8 @@ import android.app.Dialog
 import android.os.Bundle
 import androidx.fragment.app.DialogFragment
 import com.sduduzog.slimlauncher.R
-import com.sduduzog.slimlauncher.models.HomeApp
 import com.sduduzog.slimlauncher.models.CustomiseAppsViewModel
+import com.sduduzog.slimlauncher.models.HomeApp
 
 class RemoveAllAppsDialog : DialogFragment(){
 
@@ -19,7 +19,7 @@ class RemoveAllAppsDialog : DialogFragment(){
         builder.setTitle(R.string.remove_all_apps_dialog_title)
         builder.setMessage(R.string.remove_all_apps_dialog_message)
         builder.setPositiveButton("OK") {_, _ ->
-            model.remove(*apps.toTypedArray())
+            model.clearTable()
         }
         return builder.create()
     }

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/options/CustomiseAppsFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/options/CustomiseAppsFragment.kt
@@ -51,14 +51,7 @@ class CustomiseAppsFragment : BaseFragment(), OnShitDoneToAppsListener {
         viewModel.apps.observe(viewLifecycleOwner, Observer {
             it?.let { apps ->
                 adapter.setItems(apps)
-                when (apps.size) {
-                    in 0..6 -> {
-                        customise_apps_fragment_add.visibility = View.VISIBLE
-                    }
-                    else -> {
-                        customise_apps_fragment_add.visibility = View.GONE
-                    }
-                }
+                customise_apps_fragment_add.visibility = if(apps.size < 7) View.VISIBLE else View.INVISIBLE
             } ?: adapter.setItems(listOf())
         })
         customise_apps_fragment_remove_all.setOnClickListener {


### PR DESCRIPTION
Currently the removal of a `HomeApp` doesn't update any indices, this way removing the 4th app (of 7) would result in a homescreen with 3 apps on the first page, 6 on the second. It also makes it hard to add a new app, since that app (might) get a sorting index that is already in use. 

This should now be fixed, furthermore I removed some unused references in `MainViewModel` and made a small refactor in `CustomiseAppFragment`