### PR TITLE
Use data binding to update theme

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -26,7 +26,10 @@ android {
         }
     }
 
-
+    buildFeatures {
+        dataBinding = true
+        viewBinding = true
+    }
 
     buildTypes {
         named("release").configure {

--- a/app/src/main/java/com/sduduzog/slimlauncher/App.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/App.kt
@@ -1,7 +1,19 @@
 package com.sduduzog.slimlauncher
 
 import android.app.Application
+import androidx.databinding.DataBindingUtil
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
+import javax.inject.Provider
 
 @HiltAndroidApp
-class App : Application()
+class App : Application() {
+
+    @Inject
+    lateinit var bindingComponentProvider: Provider<CustomBindingComponentBuilder>
+
+    override fun onCreate() {
+        super.onCreate()
+        DataBindingUtil.setDefaultComponent(bindingComponentProvider.get().build())
+    }
+}

--- a/app/src/main/java/com/sduduzog/slimlauncher/BindingScoped.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/BindingScoped.kt
@@ -1,0 +1,7 @@
+package com.sduduzog.slimlauncher
+
+import javax.inject.Scope
+
+@Scope
+@Retention(AnnotationRetention.BINARY)
+annotation class BindingScoped

--- a/app/src/main/java/com/sduduzog/slimlauncher/ColorPalette.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ColorPalette.kt
@@ -4,4 +4,8 @@ class ColorPalette {
     fun getTextPrimaryColor(): String {
         return "#8181ff"
     }
+
+    fun getViewBackgroundColor(): String {
+        return "#ff8181"
+    }
 }

--- a/app/src/main/java/com/sduduzog/slimlauncher/ColorPalette.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ColorPalette.kt
@@ -1,0 +1,7 @@
+package com.sduduzog.slimlauncher
+
+class ColorPalette {
+    fun getTextPrimaryColor(): String {
+        return "#8181ff"
+    }
+}

--- a/app/src/main/java/com/sduduzog/slimlauncher/ColorPaletteRepository.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ColorPaletteRepository.kt
@@ -1,0 +1,3 @@
+package com.sduduzog.slimlauncher
+
+class ColorPaletteRepository{}

--- a/app/src/main/java/com/sduduzog/slimlauncher/CustomBindingComponent.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/CustomBindingComponent.kt
@@ -1,0 +1,9 @@
+package com.sduduzog.slimlauncher
+
+import androidx.databinding.DataBindingComponent
+import dagger.hilt.DefineComponent
+import dagger.hilt.android.components.ApplicationComponent
+
+@BindingScoped
+@DefineComponent(parent = ApplicationComponent::class)
+interface CustomBindingComponent : DataBindingComponent

--- a/app/src/main/java/com/sduduzog/slimlauncher/CustomBindingComponentBuilder.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/CustomBindingComponentBuilder.kt
@@ -1,0 +1,8 @@
+package com.sduduzog.slimlauncher
+
+import dagger.hilt.DefineComponent
+
+@DefineComponent.Builder
+interface CustomBindingComponentBuilder {
+    fun build(): CustomBindingComponent
+}

--- a/app/src/main/java/com/sduduzog/slimlauncher/CustomBindingEntryPoint.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/CustomBindingEntryPoint.kt
@@ -1,0 +1,12 @@
+package com.sduduzog.slimlauncher
+
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+
+@EntryPoint
+@BindingScoped
+@InstallIn(CustomBindingComponent::class)
+interface CustomBindingEntryPoint {
+    @BindingScoped
+    fun getThemeBindingAdapter() : ThemeBindingAdapter
+}

--- a/app/src/main/java/com/sduduzog/slimlauncher/ThemeBindingAdapter.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ThemeBindingAdapter.kt
@@ -2,6 +2,7 @@ package com.sduduzog.slimlauncher
 
 import android.graphics.Color
 import android.widget.TextView
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.databinding.BindingAdapter
 import javax.inject.Inject
 
@@ -10,5 +11,10 @@ class ThemeBindingAdapter @Inject constructor() {
     @BindingAdapter(value = ["themeTextColor"])
     fun setTextViewColor(textView: TextView, color: String) {
         textView.setTextColor(Color.parseColor(color))
+    }
+
+    @BindingAdapter(value = ["themeBackgroundColor"])
+    fun setViewBackgroundColor(constraintLayout: ConstraintLayout, color: String) {
+        constraintLayout.setBackgroundColor(Color.parseColor(color))
     }
 }

--- a/app/src/main/java/com/sduduzog/slimlauncher/ThemeBindingAdapter.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ThemeBindingAdapter.kt
@@ -1,0 +1,14 @@
+package com.sduduzog.slimlauncher
+
+import android.graphics.Color
+import android.widget.TextView
+import androidx.databinding.BindingAdapter
+import javax.inject.Inject
+
+class ThemeBindingAdapter @Inject constructor() {
+
+    @BindingAdapter(value = ["themeTextColor"])
+    fun setTextViewColor(textView: TextView, color: String) {
+        textView.setTextColor(Color.parseColor(color))
+    }
+}

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/options/OptionsFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/options/OptionsFragment.kt
@@ -9,8 +9,11 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.edit
+import androidx.databinding.DataBindingUtil
 import androidx.navigation.Navigation
+import com.sduduzog.slimlauncher.ColorPalette
 import com.sduduzog.slimlauncher.R
+import com.sduduzog.slimlauncher.databinding.OptionsFragmentBinding
 import com.sduduzog.slimlauncher.ui.dialogs.ChangeThemeDialog
 import com.sduduzog.slimlauncher.ui.dialogs.ChooseTimeFormatDialog
 import com.sduduzog.slimlauncher.utils.BaseFragment
@@ -20,7 +23,10 @@ class OptionsFragment : BaseFragment() {
     override fun getFragmentView(): ViewGroup = options_fragment
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.options_fragment, container, false)
+        val binding = OptionsFragmentBinding.inflate(inflater, container, false)
+        binding.lifecycleOwner = this
+        binding.colorPalette = ColorPalette()
+        return binding.root
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/sduduzog/slimlauncher/utils/BaseFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/utils/BaseFragment.kt
@@ -34,7 +34,6 @@ abstract class BaseFragment : Fragment(), ISubscriber {
             requireContext().theme.resolveAttribute(R.attr.colorPrimary, value, true)
             requireActivity().window.statusBarColor = value.data
         }
-
     }
 
     override fun onStart() {

--- a/app/src/main/res/layout/options_fragment.xml
+++ b/app/src/main/res/layout/options_fragment.xml
@@ -13,6 +13,7 @@
         android:id="@+id/options_fragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        themeBackgroundColor="@{colorPalette.viewBackgroundColor}"
         tools:context=".ui.options.OptionsFragment">
 
         <TextView

--- a/app/src/main/res/layout/options_fragment.xml
+++ b/app/src/main/res/layout/options_fragment.xml
@@ -1,99 +1,108 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/options_fragment"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".ui.options.OptionsFragment">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <TextView
-        android:id="@+id/textView5"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/_16sdp"
-        android:layout_marginLeft="@dimen/_16sdp"
-        android:layout_marginTop="@dimen/_8sdp"
-        android:text="@string/main_fragment_options"
-        android:textAppearance="@style/TextAppearance.AppCompat"
-        android:textSize="@dimen/_36ssp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+    <data>
+        <variable
+            name="colorPalette"
+            type="com.sduduzog.slimlauncher.ColorPalette" />
+    </data>
 
-    <TextView
-        android:id="@+id/options_fragment_about_slim"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="24dp"
-        android:layout_marginLeft="24dp"
-        android:layout_marginTop="32dp"
-        android:text="@string/options_fragment_about_slim"
-        android:textAppearance="@style/TextAppearance.AppCompat"
-        android:textSize="@dimen/_20ssp"
-        app:layout_constraintBottom_toTopOf="@+id/options_fragment_device_settings"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textView5"
-        app:layout_constraintVertical_bias="0.17000002"
-        app:layout_constraintVertical_chainStyle="packed" />
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/options_fragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".ui.options.OptionsFragment">
 
-    <TextView
-        android:id="@+id/options_fragment_device_settings"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="32dp"
-        android:text="@string/options_fragment_device_settings"
-        android:textAppearance="@style/TextAppearance.AppCompat"
-        android:textSize="@dimen/_20ssp"
-        app:layout_constraintBottom_toTopOf="@+id/options_fragment_change_theme"
-        app:layout_constraintStart_toStartOf="@+id/options_fragment_about_slim"
-        app:layout_constraintTop_toBottomOf="@+id/options_fragment_about_slim" />
+        <TextView
+            android:id="@+id/textView5"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/_16sdp"
+            android:layout_marginTop="@dimen/_8sdp"
+            android:text="@string/main_fragment_options"
+            android:textAppearance="@style/TextAppearance.AppCompat"
+            android:textSize="@dimen/_36ssp"
+            themeTextColor="@{colorPalette.textPrimaryColor}"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-    <TextView
-        android:id="@+id/options_fragment_change_theme"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="32dp"
-        android:text="@string/options_fragment_change_theme"
-        android:textAppearance="@style/TextAppearance.AppCompat"
-        android:textSize="@dimen/_20ssp"
-        app:layout_constraintBottom_toTopOf="@+id/options_fragment_choose_time_format"
-        app:layout_constraintStart_toStartOf="@+id/options_fragment_device_settings"
-        app:layout_constraintTop_toBottomOf="@+id/options_fragment_device_settings" />
+        <TextView
+            android:id="@+id/options_fragment_about_slim"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="24dp"
+            android:layout_marginTop="32dp"
+            android:text="@string/options_fragment_about_slim"
+            android:textAppearance="@style/TextAppearance.AppCompat"
+            android:textSize="@dimen/_20ssp"
+            app:layout_constraintBottom_toTopOf="@+id/options_fragment_device_settings"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/textView5"
+            app:layout_constraintVertical_bias="0.17000002"
+            app:layout_constraintVertical_chainStyle="packed" />
 
-    <TextView
-        android:id="@+id/options_fragment_choose_time_format"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="32dp"
-        android:text="@string/options_fragment_choose_time_format"
-        android:textAppearance="@style/TextAppearance.AppCompat"
-        android:textSize="@dimen/_20ssp"
-        app:layout_constraintBottom_toTopOf="@+id/options_fragment_toggle_status_bar"
-        app:layout_constraintStart_toStartOf="@+id/options_fragment_change_theme"
-        app:layout_constraintTop_toBottomOf="@+id/options_fragment_change_theme" />
+        <TextView
+            android:id="@+id/options_fragment_device_settings"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:text="@string/options_fragment_device_settings"
+            android:textAppearance="@style/TextAppearance.AppCompat"
+            android:textSize="@dimen/_20ssp"
+            app:layout_constraintBottom_toTopOf="@+id/options_fragment_change_theme"
+            app:layout_constraintStart_toStartOf="@+id/options_fragment_about_slim"
+            app:layout_constraintTop_toBottomOf="@+id/options_fragment_about_slim" />
 
-    <TextView
-        android:id="@+id/options_fragment_toggle_status_bar"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="32dp"
-        android:text="@string/options_fragment_toggle_status_bar"
-        android:textAppearance="@style/TextAppearance.AppCompat"
-        android:textSize="@dimen/_20ssp"
-        app:layout_constraintBottom_toTopOf="@+id/options_fragment_customise_apps"
-        app:layout_constraintStart_toStartOf="@+id/options_fragment_choose_time_format"
-        app:layout_constraintTop_toBottomOf="@+id/options_fragment_choose_time_format" />
+        <TextView
+            android:id="@+id/options_fragment_change_theme"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:text="@string/options_fragment_change_theme"
+            android:textAppearance="@style/TextAppearance.AppCompat"
+            android:textSize="@dimen/_20ssp"
+            app:layout_constraintBottom_toTopOf="@+id/options_fragment_choose_time_format"
+            app:layout_constraintStart_toStartOf="@+id/options_fragment_device_settings"
+            app:layout_constraintTop_toBottomOf="@+id/options_fragment_device_settings" />
 
-    <TextView
-        android:id="@+id/options_fragment_customise_apps"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="32dp"
-        android:layout_marginBottom="32dp"
-        android:text="@string/options_fragment_customise_apps"
-        android:textAppearance="@style/TextAppearance.AppCompat"
-        android:textSize="@dimen/_20ssp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="@+id/options_fragment_toggle_status_bar"
-        app:layout_constraintTop_toBottomOf="@+id/options_fragment_toggle_status_bar" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <TextView
+            android:id="@+id/options_fragment_choose_time_format"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:text="@string/options_fragment_choose_time_format"
+            android:textAppearance="@style/TextAppearance.AppCompat"
+            android:textSize="@dimen/_20ssp"
+            app:layout_constraintBottom_toTopOf="@+id/options_fragment_toggle_status_bar"
+            app:layout_constraintStart_toStartOf="@+id/options_fragment_change_theme"
+            app:layout_constraintTop_toBottomOf="@+id/options_fragment_change_theme" />
+
+        <TextView
+            android:id="@+id/options_fragment_toggle_status_bar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:text="@string/options_fragment_toggle_status_bar"
+            android:textAppearance="@style/TextAppearance.AppCompat"
+            android:textSize="@dimen/_20ssp"
+            app:layout_constraintBottom_toTopOf="@+id/options_fragment_customise_apps"
+            app:layout_constraintStart_toStartOf="@+id/options_fragment_choose_time_format"
+            app:layout_constraintTop_toBottomOf="@+id/options_fragment_choose_time_format" />
+
+        <TextView
+            android:id="@+id/options_fragment_customise_apps"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:layout_marginBottom="32dp"
+            android:text="@string/options_fragment_customise_apps"
+            android:textAppearance="@style/TextAppearance.AppCompat"
+            android:textSize="@dimen/_20ssp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/options_fragment_toggle_status_bar"
+            app:layout_constraintTop_toBottomOf="@+id/options_fragment_toggle_status_bar" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>


### PR DESCRIPTION
The aim with this is to introduce data binding into the project mainly to achieve two goals,
- Move user preferences to sqlite from shared preferences and:
- Stop relying on recreating the activity to update the theme, this by binding the layout to LiveData properties which will update the layout upon configuration changes

The end goal is to completely scrap the use of shared preferences from the app and only use one database to handle everything
 