### PR TITLE
Fixed the overlapped texts on the app customizing page

### DIFF
--- a/app/src/main/res/layout/customise_apps_fragment.xml
+++ b/app/src/main/res/layout/customise_apps_fragment.xml
@@ -33,7 +33,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/textView6"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/customise_apps_fragment_remove_all"
         tools:itemCount="5"
         tools:listitem="@layout/customise_apps_fragment_list_item" />
 


### PR DESCRIPTION
Dear developer:

Hello! I am the creator of issue #146, and I have fixed the overlapped texts on the app customizing page. I would genuinely appreciate it if you could kindly revise my code and leave me some advice. Thank you so much for your precious time!

Here is the screenshot after my changes:

<img src="https://user-images.githubusercontent.com/25502419/131459453-9ea9cb3a-14e1-4b04-9b90-a7e74fb9e807.png" alt="copy" width="250"/>

Thanks again! Blessings on your day! :)