### PR TITLE
Make options menu scrollable (#108)

### DIFF
--- a/app/src/main/res/layout/options_fragment.xml
+++ b/app/src/main/res/layout/options_fragment.xml
@@ -1,86 +1,94 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/options_fragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ui.options.OptionsFragment">
+    android:overScrollMode="ifContentScrolls"
+    android:scrollbars="none">
 
-    <TextView
-        android:id="@+id/textView5"
-        android:layout_width="wrap_content"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/options_fragment"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/_16sdp"
-        android:layout_marginLeft="@dimen/_16sdp"
-        android:layout_marginTop="@dimen/_8sdp"
-        android:text="@string/main_fragment_options"
-        android:textAppearance="@style/TextAppearance.AppCompat"
-        android:textSize="@dimen/_36ssp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        tools:context=".ui.options.OptionsFragment">
 
-    <TextView
-        android:id="@+id/options_fragment_device_settings"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/options_fragment_device_settings"
-        android:textAppearance="@style/TextAppearance.AppCompat"
-        android:layout_marginStart="24dp"
-        android:layout_marginTop="32dp"
-        android:textSize="@dimen/_20ssp"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toTopOf="@+id/options_fragment_change_theme"
-        app:layout_constraintVertical_bias="0.17000002"
-        app:layout_constraintVertical_chainStyle="packed"
-        app:layout_constraintTop_toBottomOf="@+id/textView5" />
+        <TextView
+            android:id="@+id/textView5"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/_16sdp"
+            android:layout_marginLeft="@dimen/_16sdp"
+            android:layout_marginTop="@dimen/_8sdp"
+            android:text="@string/main_fragment_options"
+            android:textAppearance="@style/TextAppearance.AppCompat"
+            android:textSize="@dimen/_36ssp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-    <TextView
-        android:id="@+id/options_fragment_change_theme"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="32dp"
-        android:text="@string/options_fragment_change_theme"
-        android:textAppearance="@style/TextAppearance.AppCompat"
-        android:textSize="@dimen/_20ssp"
-        app:layout_constraintBottom_toTopOf="@+id/options_fragment_choose_time_format"
-        app:layout_constraintStart_toStartOf="@+id/options_fragment_device_settings"
-        app:layout_constraintTop_toBottomOf="@+id/options_fragment_device_settings" />
+        <TextView
+            android:id="@+id/options_fragment_device_settings"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/options_fragment_device_settings"
+            android:textAppearance="@style/TextAppearance.AppCompat"
+            android:layout_marginStart="24dp"
+            android:layout_marginTop="32dp"
+            android:textSize="@dimen/_20ssp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/options_fragment_change_theme"
+            app:layout_constraintVertical_bias="0.17000002"
+            app:layout_constraintVertical_chainStyle="packed"
+            app:layout_constraintTop_toBottomOf="@+id/textView5" />
 
-    <TextView
-        android:id="@+id/options_fragment_choose_time_format"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="32dp"
-        android:text="@string/options_fragment_choose_time_format"
-        android:textAppearance="@style/TextAppearance.AppCompat"
-        android:textSize="@dimen/_20ssp"
-        app:layout_constraintBottom_toTopOf="@+id/options_fragment_toggle_status_bar"
-        app:layout_constraintStart_toStartOf="@+id/options_fragment_change_theme"
-        app:layout_constraintTop_toBottomOf="@+id/options_fragment_change_theme" />
+        <TextView
+            android:id="@+id/options_fragment_change_theme"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:text="@string/options_fragment_change_theme"
+            android:textAppearance="@style/TextAppearance.AppCompat"
+            android:textSize="@dimen/_20ssp"
+            app:layout_constraintBottom_toTopOf="@+id/options_fragment_choose_time_format"
+            app:layout_constraintStart_toStartOf="@+id/options_fragment_device_settings"
+            app:layout_constraintTop_toBottomOf="@+id/options_fragment_device_settings" />
 
-    <TextView
-        android:id="@+id/options_fragment_toggle_status_bar"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="32dp"
-        android:text="@string/options_fragment_toggle_status_bar"
-        android:textAppearance="@style/TextAppearance.AppCompat"
-        android:textSize="@dimen/_20ssp"
-        app:layout_constraintBottom_toTopOf="@+id/options_fragment_customise_apps"
-        app:layout_constraintStart_toStartOf="@+id/options_fragment_choose_time_format"
-        app:layout_constraintTop_toBottomOf="@+id/options_fragment_choose_time_format" />
+        <TextView
+            android:id="@+id/options_fragment_choose_time_format"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:text="@string/options_fragment_choose_time_format"
+            android:textAppearance="@style/TextAppearance.AppCompat"
+            android:textSize="@dimen/_20ssp"
+            app:layout_constraintBottom_toTopOf="@+id/options_fragment_toggle_status_bar"
+            app:layout_constraintStart_toStartOf="@+id/options_fragment_change_theme"
+            app:layout_constraintTop_toBottomOf="@+id/options_fragment_change_theme" />
 
-    <TextView
-        android:id="@+id/options_fragment_customise_apps"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="32dp"
-        android:layout_marginBottom="32dp"
-        android:text="@string/options_fragment_customise_apps"
-        android:textAppearance="@style/TextAppearance.AppCompat"
-        android:textSize="@dimen/_20ssp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintStart_toStartOf="@+id/options_fragment_toggle_status_bar"
-        app:layout_constraintTop_toBottomOf="@+id/options_fragment_toggle_status_bar" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <TextView
+            android:id="@+id/options_fragment_toggle_status_bar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:text="@string/options_fragment_toggle_status_bar"
+            android:textAppearance="@style/TextAppearance.AppCompat"
+            android:textSize="@dimen/_20ssp"
+            app:layout_constraintBottom_toTopOf="@+id/options_fragment_customise_apps"
+            app:layout_constraintStart_toStartOf="@+id/options_fragment_choose_time_format"
+            app:layout_constraintTop_toBottomOf="@+id/options_fragment_choose_time_format" />
+
+        <TextView
+            android:id="@+id/options_fragment_customise_apps"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:layout_marginBottom="32dp"
+            android:text="@string/options_fragment_customise_apps"
+            android:textAppearance="@style/TextAppearance.AppCompat"
+            android:textSize="@dimen/_20ssp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="@+id/options_fragment_toggle_status_bar"
+            app:layout_constraintTop_toBottomOf="@+id/options_fragment_toggle_status_bar" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</ScrollView>


### PR DESCRIPTION
This is a minor change and is not really necessary while the app is locked in portrait mode. But, it would be useful to have this change implemented if we ever end up [supporting landscape mode](https://github.com/sduduzog/slim-launcher/issues/45) so that the options can scroll properly.

For reference:
- https://github.com/jkuester/unlauncher/pull/108
- https://github.com/jkuester/unlauncher/issues/83

Co-authored-by: bakio86 <bakio86@mi.fu-berlin.de>
