### PR TITLE
Replace deprecated `onActivityCreated` with `onViewCreated`

### DIFF
--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
@@ -37,8 +37,8 @@ class HomeFragment : BaseFragment(), OnLaunchAppListener {
         return inflater.inflate(R.layout.home_fragment, container, false)
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         val adapter1 = HomeAdapter(this)
         val adapter2 = HomeAdapter(this)
         home_fragment_list.adapter = adapter1

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/options/AddAppFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/options/AddAppFragment.kt
@@ -33,8 +33,8 @@ class AddAppFragment : BaseFragment(), OnAppClickedListener {
         return inflater.inflate(R.layout.add_app_fragment, container, false)
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         val adapter = AddAppAdapter(this)
 
         add_app_fragment_list.adapter = adapter

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/options/CustomiseAppsFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/options/CustomiseAppsFragment.kt
@@ -34,9 +34,8 @@ class CustomiseAppsFragment : BaseFragment(), OnShitDoneToAppsListener {
         return inflater.inflate(R.layout.customise_apps_fragment, container, false)
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
-
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         val adapter = CustomAppsAdapter(this)
 
         viewModel.apps.observe(viewLifecycleOwner, {

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/options/OptionsFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/options/OptionsFragment.kt
@@ -22,8 +22,8 @@ class OptionsFragment : BaseFragment() {
         return inflater.inflate(R.layout.options_fragment, container, false)
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         options_fragment_device_settings.setOnClickListener {
             val intent = Intent(Settings.ACTION_SETTINGS)
             launchActivity(it, intent)


### PR DESCRIPTION
See https://github.com/jkuester/unlauncher/pull/119 for more information.  

Co-authored-by: bakio86 <bakio86@mi.fu-berlin.de>
Co-authored-by: Joshua Kuestersteffen <jkuester@kuester7.com>